### PR TITLE
Add source

### DIFF
--- a/smoke_tests/spack_repo/smoketest/packages/smoke1/smoke1-src/CMakeLists.txt
+++ b/smoke_tests/spack_repo/smoketest/packages/smoke1/smoke1-src/CMakeLists.txt
@@ -1,0 +1,8 @@
+# a simple CXX only test case
+cmake_minimum_required(VERSION 3.10)
+project (SimpleSmokeTest CXX)
+
+add_executable (smoke1 add.cxx)
+
+install (TARGETS smoke1 DESTINATION bin)
+

--- a/smoke_tests/spack_repo/smoketest/packages/smoke1/smoke1-src/add.cxx
+++ b/smoke_tests/spack_repo/smoketest/packages/smoke1/smoke1-src/add.cxx
@@ -1,0 +1,12 @@
+#include <iostream>
+
+int main(int argc, char ** argv){
+    if(argc != 3) {
+        std::cerr << "Improper number of arguments (" << argc-1 << "), 2 were expected\n";
+        return 1;
+    }
+    int a = atoi(argv[1]);
+    int b = atoi(argv[2]);
+    std::cout << "Result: " << a + b << "\n";
+    return 0;
+}


### PR DESCRIPTION
Previously source for Smoke test packages was only available in a tarball. 
Check actual source into VC as well so it's clear what the smoke packages are testing.
Leave the original tarballs for use with Spack's package url mechanism and to avoid an extra step when setting up this workflow.